### PR TITLE
`scrextend` 2022-05-16 更新后不兼容; Remove scrextend; refine footnote mark

### DIFF
--- a/tex/pkuthss.cls
+++ b/tex/pkuthss.cls
@@ -152,7 +152,7 @@
 	% make footnote rule `Word'-like
 	\renewcommand\footnoterule{%
 		\kern-6\p@
-		\hrule\@width 2in
+		\hrule\@width.32\columnwidth
 		\kern5.6\p@}
 \fi
 

--- a/tex/pkuthss.cls
+++ b/tex/pkuthss.cls
@@ -132,9 +132,9 @@
 	% Circled text, cf. <https://tex.stackexchange.com/questions/7032/>.
 	\RequirePackage{tikz}
 	\newcommand*{\thss@int@circled}[1]{%
-		\scalebox{0.8}{\tikz[baseline = (char.base)]{
+		\scalebox{0.8}{\tikz[baseline ={([yshift=-0.1\ccwd]char.base)}]{
 			\node[
-				shape = circle, draw = black, minimum size = 1.25em, inner sep = 0pt
+				shape = circle, draw = black, minimum size = 1.25\ccwd, inner sep = 0pt
 			] (char) {#1};
 		}}%
 	}
@@ -142,11 +142,18 @@
 	% footnote is rarely used in dissertation covers ;)
 	\renewcommand*{\thefootnote}%
 		{\protect\thss@int@circled{\arabic{footnote}}}
-	% Provides utility to modify footnote spacing.
-	% Option used to make sure it does not render interleaf pages totally blank.
-	\RequirePackage[cleardoublepage = current]{scrextend}
-	% Set up footnote spacing: whole paragraph indent 2 ccwd, 0.5 ccwd after mark.
-	\deffootnote{2\ccwd}{0pt}{\thefootnotemark\hspace{0.5\ccwd}}
+	% make footnote follow the guideline; remove scrextend
+	% make footnote mark in the footnote \normalsize
+	\renewcommand\@makefntext[1]{%
+		\setlength{\leftskip}{1.5\ccwd}%
+		\parindent 2em%
+		\noindent
+		\hb@xt@0pt{\hss\@thefnmark\hspace{.5\ccwd}}#1}
+	% make footnote rule `Word'-like
+	\renewcommand\footnoterule{%
+		\kern-6\p@
+		\hrule\@width 2in
+		\kern5.6\p@}
 \fi
 
 \ifthss@opt@pkuspace


### PR DESCRIPTION
在 `koma-script` 2022-05-16 的 v3.36 中，`scrextend.sty` 不再接受 `cleardoublepage` 选项，导致 https://github.com/CasperVector/pkuthss/blob/b80742e3c67bc5837dbb6c057a42b834315e9ced/tex/pkuthss.cls#L147 编译报错。

引入 `scrextend.sty` 是为了重定义脚注。这可以直接通过重定义 `\@makefntext` 实现而不需要外部宏包。
```latex
\renewcommand\@makefntext[1]{%
	\setlength{\leftskip}{1.5\ccwd}% 悬挂缩进 1.5 字符
	\parindent 2em% 如果脚注中分段, 新段首行缩进 2 字符
	\noindent% 首段不缩进, 从而直接跟着序号的 box
	\hb@xt@0pt{\hss\@thefnmark\hspace{.5\ccwd}}#1}% 实现带圈序号 1 字符, 后跟 0.5 字符间距.
	% 特别是, 这里直接用 \@thefnmark 而不用 \@makefnmark, 避免其上标
```
此外，
1. 更改了带圈序号绘图命令，使其相对基线上移 0.1em，从而这个直径 1.0em 的圈竖直方向上和其他文字居中、更美观。
2. 微调了脚注的分界线的长度和位置，使其更像 M$-Word（以及更丑）
