### PR TITLE
Support numbered pdf bookmarks and Chinese pdf properties

### DIFF
--- a/tex/pkuthss.cls
+++ b/tex/pkuthss.cls
@@ -65,9 +65,6 @@
 % Process all class options now.
 \ProcessOptions\relax
 
-% Work around the `\lvert already defined' error.
-% cf. <https://github.com/CTeX-org/ctex-kit/issues/454>.
-\ifthss@opt@pkufont\RequirePackage{amsmath}\fi
 % pkuthss is based on ctexbook; we use `xiao 4' as default font size.
 \LoadClass[zihao = -4]{ctexbook}[2014/03/06]
 % ctex 2.x no longer loads ifpdf and ifxetex by itself.
@@ -83,10 +80,11 @@
 % Provides `\uline' used in `\maketitle' (but do not mess with `\emph').
 \RequirePackage[normalem]{ulem}
 % `\AtEndOfClass' used to avoid `PDF destination not defined' with setspace.
-\AtEndOfClass{\RequirePackage{hyperref}}
+\AtEndOfClass{\RequirePackage[bookmarksnumbered, unicode]{hyperref}}
 \input{pkuthss.def}
 
 \ifthss@opt@pkufont
+	\RequirePackage{amsmath}
 	% Use Times New Roman / Arial according to school regulation.
 	\ifxetex
 		\RequirePackage{unicode-math}
@@ -218,8 +216,8 @@
 		% information does not leak into the blind version.
 		\newcommand*{\setpdfproperties}{%
 			\hypersetup{
-				pdfauthor = {\@eauthor}, pdftitle = {\@etitle},
-				pdfsubject = {\euniversity\ \ethesisname}, pdfkeywords = {\@ekeywords}
+				pdfauthor = {\@cauthor}, pdftitle = {\@ctitle},
+				pdfsubject = {\cuniversity\cthesisname}, pdfkeywords = {\@ckeywords}
 			}%
 		}
 		% Set up the properties when generating the title page because the document
@@ -277,7 +275,7 @@
 % Set up page layout.
 \geometry{a4paper, hmargin = 2.6cm, headheight = 0.5cm, headsep = 0.6cm}
 \ifthss@opt@ugly
-	\geometry{top = 3.1cm, bottom = 3.0cm, footskip = 0.8cm}
+	\geometry{top = 3.1cm, bottom = 2.5cm, footskip = 0.8cm}
 \else
 	\geometry{top = 3.0cm, bottom = 3.1cm, footskip = 1.1cm}
 \fi

--- a/tex/pkuthss.def
+++ b/tex/pkuthss.def
@@ -25,18 +25,13 @@
 \ProvidesFile{pkuthss.def}
 	[2024/03/07 v1.9.4 Labels and captions for the pkuthss document class]
 
-\def\label@ementor{Directed by\ }
 \def\euniversity{Peking University}
 \def\ethesisname{Doctor Thesis}
 \def\thesiscover{}
 \def\mentorlines{1}
 \def\eabstractname{ABSTRACT}
-
-\ifthss@opt@ugly
-	\def\label@ekeywords{KEY WORDS:\ }
-\else
-	\def\label@ekeywords{KEYWORDS:\ }
-\fi
+\def\label@ementor{Supervised by\ }
+\def\label@ekeywords{KEY WORDS:\ }
 
 \ifthss@opt@gbk
 	\input{pkuthss-gbk.def}


### PR DESCRIPTION
# Change Log
## 1 Support numbered pdf bookmarks
> tex/pkuthss.cls Line 86/83

Add options `bookmarksnumbered, unicode` for `hyperref`.
This change supports numbered pdf bookmarks.
For example, former bookmark '引言' will turn into '第一章 引言'.
## 2 Support Chinese pdf properties
> tex/pkuthss.cls Line 221-222/219-220

Change `eauthor` to `cauthor`,  `etitle` to `ctitle`, etc.
## 3 Format adjustment
According to the latest [official template](https://grs.pku.edu.cn/xwgz11/xwsy11/bsxw111/clxz09/346375.htm):
> tex/pkuthss.cls Line 280/278

Change `bottom = 3.0cm` to `bottom = 2.5cm` .

> tex/pkuthss.def Line 28-39/33-34

Change `Directed by\ ` to `Supervised by\ ` .
Change `KEYWORDS:\ ` to `KEY WORDS:\ ` .

## 4 Code cleanup
> tex/pkuthss.def Line 68-70/87

This error was caused by a bug in the package `ulem` and has been fixed offcially.
See also [ctex: 与 amsmath 的兼容性问题](https://github.com/CTeX-org/ctex-kit/issues/470).

